### PR TITLE
Add support for "issuer" parameter and fix tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,9 @@
         "christian-riesen/base32": "1.2",
         "zendframework/zend-math": ">=2.2"
     },
+    "require-dev": {
+        "phpunit/phpunit": "4.3.*"
+    },
     "autoload": {
         "psr-0": {
             "GoogleAuthenticator\\": "src"

--- a/src/GoogleAuthenticator/GoogleAuthenticator.php
+++ b/src/GoogleAuthenticator/GoogleAuthenticator.php
@@ -25,6 +25,9 @@ class GoogleAuthenticator
     const CODE_LENGTH = 6;
     const SECRET_LENGTH = 16;
 
+    /** @var string $issuer */
+    protected $issuer;
+
     /** @var string $secretKey */
     protected $secretKey;
 
@@ -82,6 +85,12 @@ class GoogleAuthenticator
      */
     public function getQRCodeUrl($applicationName, $size = 200)
     {
+        $params = array('secret' => $this->getSecretKey());
+
+        if ($this->issuer) {
+            $params['issuer'] = $this->issuer;
+        }
+
         return str_replace(
             array(
                 '{chs}',
@@ -89,7 +98,7 @@ class GoogleAuthenticator
             ),
             array(
                 $size . 'x' . $size,
-                urlencode('otpauth://totp/' . $applicationName . '?secret=' . $this->getSecretKey())
+                urlencode('otpauth://totp/' . $applicationName . '?' . http_build_query($params))
             ),
             static::API_URL
         );
@@ -101,6 +110,19 @@ class GoogleAuthenticator
     public function getSecretKey()
     {
         return $this->secretKey;
+    }
+
+    /**
+     * Set the issuer name (Appears above code in Google Authenticator)
+     *
+     * @param string $issuer
+     * @return GoogleAuthenticator
+     */
+    public function setIssuer($issuer)
+    {
+        $this->issuer = $issuer;
+
+        return $this;
     }
 
     /**

--- a/tests/GoogleAuthenticatorTest.php
+++ b/tests/GoogleAuthenticatorTest.php
@@ -1,13 +1,30 @@
 <?php
 
-namespace GoogleAuthenticatorTest;
+namespace GoogleAuthenticator;
 
-use GoogleAuthenticator\GoogleAuthenticator;
-
-class GoogleAuthenticatorTest extends PHPUnit_Framework_TestCase
+/**
+ * Override time() in current namespace for testing
+ * see http://www.schmengler-se.de/en/2011/03/php-mocking-built-in-functions-like-time-in-unit-tests/
+ *
+ * @return int
+ */
+function time()
 {
-    /* @var $googleAuthenticator GoogleAuthenticator */
+    return GoogleAuthenticatorTest::$now ?: time();
+}
+
+
+class GoogleAuthenticatorTest extends \PHPUnit_Framework_TestCase
+{
+    /** @var $googleAuthenticator GoogleAuthenticator */
     protected $googleAuthenticator;
+
+    /**
+     * Timestamp that will be returned by time()
+     *
+     * @var int $now
+     */
+    public static $now;
 
     protected function setUp()
     {
@@ -18,9 +35,10 @@ class GoogleAuthenticatorTest extends PHPUnit_Framework_TestCase
     {
         // Secret, time, code
         return array(
-            array('SECRET', '0', '200470'),
-            array('SECRET', '1385909245', '780018'),
-            array('SECRET', '1378934578', '705013'),
+            array('SECRET', 0, '857148'),
+            array('SECRET', 1385909245, '979377'),
+            array('SECRET', 1378934578, '560773'),
+            array('SECRET2', 1378934578, '394728'),
         );
     }
 
@@ -34,17 +52,20 @@ class GoogleAuthenticatorTest extends PHPUnit_Framework_TestCase
     {
         $ga = $this->googleAuthenticator;
         $secret = $ga->generateSecretKey();
-        $this->assertEquals(strlen($secret), 16);
+        $this->assertEquals(16, strlen($secret));
     }
 
     /**
      * @dataProvider codeProvider
      */
-    public function testgetCodeReturnsCorrectValues($secret, $timeSlice, $code)
+    public function testgetCodeReturnsCorrectValues($secret, $time, $code)
     {
-        $generatedCode = $this->googleAuthenticator->getCode($secret, $timeSlice);
+        static::$now = $time;
 
-        $this->assertEquals($code, $generatedCode);
+        $this->googleAuthenticator->setSecretKey($secret);
+        $generatedCode = $this->googleAuthenticator->getCode($time);
+
+        $this->assertEquals($code, $generatedCode, 'Invalid code for ' . $secret . ' at ' . $time);
     }
 
     public function testgetQRCodeUrlReturnsCorrectUrl()
@@ -56,12 +77,29 @@ class GoogleAuthenticatorTest extends PHPUnit_Framework_TestCase
         $urlParts = parse_url($url);
         parse_str($urlParts['query'], $queryStringArray);
 
-        $this->assertEquals($urlParts['scheme'], 'https');
-        $this->assertEquals($urlParts['host'], 'chart.googleapis.com');
-        $this->assertEquals($urlParts['path'], '/chart');
+        $this->assertEquals('https', $urlParts['scheme']);
+        $this->assertEquals('chart.googleapis.com', $urlParts['host']);
+        $this->assertEquals('/chart', $urlParts['path']);
 
         $expectedChl = 'otpauth://totp/' . $name . '?secret=' . $secret;
-        $this->assertEquals($queryStringArray['chl'], $expectedChl);
+        $this->assertEquals($expectedChl, $queryStringArray['chl']);
+    }
+
+    public function testgetQRCodeUrlReturnsCorrectUrlWhenIssuerSet()
+    {
+        $secret = 'SECRET';
+        $name   = 'Test';
+        $issuer = 'Test Co';
+        $url = $this->googleAuthenticator
+            ->setSecretKey($secret)
+            ->setIssuer($issuer)
+            ->getQRCodeUrl($name);
+
+        $urlParts = parse_url($url);
+        parse_str($urlParts['query'], $queryStringArray);
+
+        $expectedChl = 'otpauth://totp/' . $name . '?secret=' . $secret . '&issuer=' . urlencode($issuer);
+        $this->assertEquals($expectedChl, $queryStringArray['chl']);
     }
 
     public function testVerifyCode()


### PR DESCRIPTION
We are looking to use this library at Hootsuite, and need the `issuer` parameter, which displays above the code in Google Authenticator. (For an example, compare the Authenticator entry for codes generated by this library with Github's code. It shows "Github" at the top, and "github.com/kbanman" below).

Additionally, I fixed the unit tests and cleaned up whitespace.
